### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/jekyll-docker.yml
+++ b/.github/workflows/jekyll-docker.yml
@@ -1,4 +1,6 @@
 name: Jekyll site CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/WdAbdo56/wdabdo56/security/code-scanning/1](https://github.com/WdAbdo56/wdabdo56/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow, specifying the minimal required privileges for the GITHUB_TOKEN. As the workflow only checks out the code and performs a docker build, it does not need any write access to repository contents, issues, or pull requests. Setting `permissions: contents: read` at the workflow root will restrict the GITHUB_TOKEN to read-only repository contents for all jobs unless otherwise overridden by per-job permissions. The edit should be made at the top level of the workflow file, immediately after the workflow `name` and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
